### PR TITLE
Feature/#12 create user model

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,4 +4,36 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable,
          :confirmable, :lockable, :timeoutable
+
+  has_one_attached :profile_image
+
+  has_many :pets, dependent: :destroy
+  has_many :my_posts, through: :pets, source: :posts
+  has_many :favorites, dependent: :destroy
+  has_many :favorite_posts, through: :favorites, source: :posts
+  has_many :comments, dependent: :destroy
+
+  validates :username, presence: true
+  validates :introduce, length: { maximum: 150 }
+
+  # 自分がフォローしているユーザとの関連
+  has_many :active_relationships, class_name: "Relationship", foreign_key: :follower_id
+  has_many :followings, through: :active_relationships, source: :followed
+
+  # 自分をフォローしているユーザとの関連
+  has_many :passive_relationships, class_name: "Relationship", foreign_key: :followed_id
+  has_many :followers, through: :passive_relationships, source: :follower
+
+  def follow(other_user)
+    following << other_user
+  end
+
+  def unfollow(other_user)
+    active_relationships.find_by(followed_id: other_user.id).destroy
+  end
+
+  # フォロー済みかチェック
+  def following?(other_user)
+    following.include?(other_user)
+  end
 end

--- a/db/migrate/20200905025440_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20200905025440_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,27 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
+  def change
+    create_table :active_storage_blobs do |t|
+      t.string   :key,        null: false
+      t.string   :filename,   null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.bigint   :byte_size,  null: false
+      t.string   :checksum,   null: false
+      t.datetime :created_at, null: false
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false
+      t.references :blob,     null: false
+
+      t.datetime :created_at, null: false
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: "index_active_storage_attachments_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+end

--- a/db/migrate/20200905133324_add_introduce_to_users.rb
+++ b/db/migrate/20200905133324_add_introduce_to_users.rb
@@ -1,0 +1,5 @@
+class AddIntroduceToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :introduce, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,28 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_15_145126) do
+ActiveRecord::Schema.define(version: 2020_09_05_025440) do
+
+  create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.bigint "byte_size", null: false
+    t.string "checksum", null: false
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -34,4 +55,5 @@ ActiveRecord::Schema.define(version: 2020_08_15_145126) do
     t.index ["unlock_token"], name: "index_users_on_unlock_token", unique: true
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_05_025440) do
+ActiveRecord::Schema.define(version: 2020_09_05_133324) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
@@ -49,6 +49,7 @@ ActiveRecord::Schema.define(version: 2020_09_05_025440) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "username"
+    t.text "introduce"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true


### PR DESCRIPTION
## チケットへのリンク
closes #12 

## やったこと

ユーザプロフィール画像の保存のためにActiveStorageを導入
ユーザモデルにリレーションシップを作成
ユーザモデルの項目として、自己紹介文(introduce)、プロフィール画像を追加
バリデーションの追加

## やらないこと

model specは未作成

* 何ができるようになるのか？（あれば。無いなら「無し」でOK）

ユーザの情報として自己紹介文とプロフィール画像を保存できる
※コントローラは別issueで修正するため、画面からの登録はまだできない

* 何ができなくなるのか？（あれば。無いなら「無し」でOK）
なし

## 動作確認

未実施

## その他

* レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
なし